### PR TITLE
feat: マイクロポストに含まれるURLをリンクにする

### DIFF
--- a/app/helpers/microposts_helper.rb
+++ b/app/helpers/microposts_helper.rb
@@ -1,2 +1,8 @@
 module MicropostsHelper
+  URL_EXP = %r{(https?://[a-z0-9-]+(?:\.[a-z]+)+(?:/[a-zA-Z0-9-]*)*[a-zA-Z0-9\-_?=&#]*)}.freeze
+
+  # stringがURLであればtrueを返す
+  def url?(string)
+    URL_EXP.match? string
+  end
 end

--- a/app/models/micropost.rb
+++ b/app/models/micropost.rb
@@ -1,4 +1,6 @@
 class Micropost < ApplicationRecord
+  include MicropostsHelper
+
   belongs_to :user
   has_one_attached :image do |attachable|
     attachable.variant :display, resize_to_limit: [500, 500]
@@ -7,7 +9,13 @@ class Micropost < ApplicationRecord
   validates :user_id, presence: true
   validates :content, presence: true, length: { maximum: 140 }
   validates :image,   content_type: { in: %w[image/jpeg image/gif image/png],
-                                      message: "must be a valid image format" },
-                      size:         { less_than: 5.megabytes,
-                                      message:   "should be less than 5MB" }
+                                      message: 'must be a valid image format' },
+                      size: { less_than: 5.megabytes,
+                              message: 'should be less than 5MB' }
+
+  def content_url_splitted
+    content.split(URL_EXP).map do |text|
+      { value: text, is_url: url?(text) }
+    end
+  end
 end

--- a/app/models/micropost.rb
+++ b/app/models/micropost.rb
@@ -18,4 +18,12 @@ class Micropost < ApplicationRecord
       { value: text, is_url: url?(text) }
     end
   end
+
+  def content_html
+    content_url_splitted.map do |elem|
+      value = elem[:value]
+      is_url = elem[:is_url]
+      is_url ? %(<a href="#{value}">#{value}</a>) : value
+    end.join
+  end
 end

--- a/app/views/microposts/_micropost.html.erb
+++ b/app/views/microposts/_micropost.html.erb
@@ -2,7 +2,14 @@
   <%= link_to gravatar_for(micropost.user, size: 50), micropost.user %>
   <span class="user"><%= link_to micropost.user.name, micropost.user %></span>
   <span class="content">
-    <%= micropost.content %>
+    <% micropost.content_url_splitted.each do |elem| %><%#
+      %><% case %><%#
+      %><% when elem[:is_url] %><%#
+        %><%= link_to elem[:value], elem[:value] %><%#
+      %><% else %><%#
+        %><%= elem[:value] %><%#
+      %><% end %><%#
+    %><% end %>
     <% if micropost.image.attached? %>
       <%= image_tag micropost.image.variant(:display) %>
     <% end %>

--- a/test/helpers/microposts_helper_test.rb
+++ b/test/helpers/microposts_helper_test.rb
@@ -1,0 +1,40 @@
+require 'test_helper'
+
+class MicropostsHelperTest < ActionView::TestCase
+  include MicropostsHelper
+
+  test 'url validation should accept valid url' do
+    valid_urls = %w[
+      http://google.com https://google.com
+      https://google.com/ https://google.com/some/path
+      https://mails.google.com
+    ]
+
+    valid_urls.each do |valid_url|
+      assert url?(valid_url)
+    end
+  end
+
+  test 'url validation should accept valid url with tag and parameters' do
+    valid_urls = %w[
+      http://google.com#some_tag
+      https://google.com?some=param&other=param
+      https://google.com/some/path?some=param123&other=param456#ANY_OTHER_TAG789
+    ]
+
+    valid_urls.each do |valid_url|
+      assert url?(valid_url)
+    end
+  end
+
+  test 'url validation should not accept invalid url' do
+    invalid_urls = %w[
+      http:://google.com https:/google.com
+      https://googlecom/ https://GOOGLE.COM
+    ]
+
+    invalid_urls.each do |invalid_url|
+      assert_not url?(invalid_url)
+    end
+  end
+end

--- a/test/integration/users_profile_test.rb
+++ b/test/integration/users_profile_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 class UsersProfileTest < ActionDispatch::IntegrationTest
   include ApplicationHelper
@@ -7,7 +7,7 @@ class UsersProfileTest < ActionDispatch::IntegrationTest
     @user = users(:michael)
   end
 
-  test "profile display" do
+  test 'profile display' do
     get user_path(@user)
     assert_template 'users/show'
     assert_select 'title', full_title(@user.name)
@@ -16,7 +16,7 @@ class UsersProfileTest < ActionDispatch::IntegrationTest
     assert_match @user.microposts.count.to_s, response.body
     assert_select 'div.pagination'
     @user.microposts.paginate(page: 1).each do |micropost|
-      assert_match micropost.content, response.body
+      assert_match micropost.content_html, response.body
     end
   end
 end


### PR DESCRIPTION
Close #16 

### やったこと
- マイクロポストにURLが含まれる場合、`<a>`タグによるハイパーリンクで表示するようにしました。
  - サブドメインや`#`によるタグ付け、`?`, `&`, `=`によるクエリパラメータもURLとして認識します。
- URLを判定するヘルパー`MicropostsHelper`を作りました。
  - テストも書きました。
- `UsersProfileTest`のテスト`profile display`を修正しました。
  - テスト`profile display`は`content`とHTML上の戻り値を比較していましたが、上の変更によりURLが含まれる場合は`content`とHTMLの戻り値が異なるようになりました。
  - よって、期待されるHTML上の表現を返す`Micropost#content_html`メソッドを作り、こちらを比較に使うようにしました。

![image](https://github.com/NaCl-Ltd/intern-2023-B/assets/77904659/7b65fea4-5c88-4c0f-a2cc-84e89d4650be)
![image](https://github.com/NaCl-Ltd/intern-2023-B/assets/77904659/24e85863-b566-4fb9-9dfe-dc268d2c7827)
