### PR TITLE
feat: userの表示に`shared/stats`を追加

### DIFF
--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -6,6 +6,8 @@
       turbo_confirm: "You sure?" } %>
       
   <% end %>
+  <% @user = user %>
+  <%= render 'shared/stats' %>
   <p style = "overflow-wrap: break-word;">
     <%= user.introduce %>
   </p>

--- a/app/views/users/show_follow.html.erb
+++ b/app/views/users/show_follow.html.erb
@@ -3,7 +3,10 @@
   <aside class="col-md-4">
     <section class="user_info">
       <%= gravatar_for @user %>
-      <h1><%= @user.name %></h1>
+      <h1>
+        <%= @user.name %><%#
+        %><span class="nickname"><%= @user.nickname %></span>
+      </h1>
       <span><%= link_to "マイページ", @user %></span>
       <span><strong>Microposts:</strong> <%= @user.microposts.count %></span>
     </section>


### PR DESCRIPTION
Close #19 

### やったこと
- userの表示にフォロー/フォロワーの数を表示するようにしました。
  - `views/shared/_stats.html.erb`がそのまま使えそうだったので使いました。~二行しか書いてないです~
- フォロー/フォロワーページにも`nickname`を表示しました。
  
### スクリーンショット
![image](https://github.com/NaCl-Ltd/intern-2023-B/assets/77904659/6163a344-6e5c-4892-85a3-a3188c8900d0)
