### PR TITLE
feat: アプリを日本語と英語に対応

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   include SessionsHelper
+  around_action :switch_locale
 
   private
 
@@ -10,5 +11,16 @@ class ApplicationController < ActionController::Base
         flash[:danger] = "Please log in."
         redirect_to login_url, status: :see_other
       end
+    end
+
+    # クエリパラメータのlocaleを遷移後も引き継ぐ
+    def default_url_options
+      { locale: I18n.locale }
+    end
+
+    # クエリパラメータでlocaleを変える
+    def switch_locale(&action)
+      locale = params[:locale] || I18n.default_locale
+      I18n.with_locale(locale, &action)
     end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -48,14 +48,14 @@ class UsersController < ApplicationController
   end
 
   def following
-    @title = "フォロー"
+    @title = I18n.t :following
     @user  = User.find(params[:id])
     @users = @user.following.paginate(page: params[:page])
     render 'show_follow', status: :unprocessable_entity
   end
 
   def followers
-    @title = "フォロワー"
+    @title = I18n.t :followers
     @user  = User.find(params[:id])
     @users = @user.followers.paginate(page: params[:page])
     render 'show_follow', status: :unprocessable_entity

--- a/app/helpers/microposts_helper.rb
+++ b/app/helpers/microposts_helper.rb
@@ -12,17 +12,14 @@ module MicropostsHelper
     true
   end
 
-  # stringのリンクのパス(`href`)を返す リンクにすべき文字列でなければnilを返す
-  def generate_link_path(string)
+  # stringのリンク(link_toのリンク先オブジェクト)を返す リンクにすべき文字列でなければnilを返す
+  def generate_link(string)
     case string
     when ->(s) { url? s }
-      return string
+      string
     when ->(s) { nickname? s }
-      user_mentioned = get_user_in_following_followers(string)
-      return "/users/#{user_mentioned.id}" if user_mentioned
+      get_user_in_following_followers(string)
     end
-
-    nil
   end
 
   # stringがURLであればtrueを返す

--- a/app/models/micropost.rb
+++ b/app/models/micropost.rb
@@ -15,7 +15,7 @@ class Micropost < ApplicationRecord
 
   def content_splitted
     content.split(LINK_EXP).map do |string|
-      { value: string, is_link: link?(string), to: generate_link_path(string) }
+      { value: string, is_link: link?(string), to: generate_link(string) }
     end
   end
 

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,7 +1,7 @@
 <header class="navbar navbar-fixed-top navbar-inverse">
   <div class="container">
       <%= image_tag("ruby.png", id: "logo_icon", alt: "Ruby logo", width: "30px") %>
-      <%= link_to "わんわんお", root_path, id: "logo" %>
+      <%= link_to t(:bow_wow_woo), root_path, id: "logo" %>
     </ul>
     <nav>
       <div class="navbar-header">
@@ -14,26 +14,26 @@
       </div>
       <ul id="navbar-menu"
           class="nav navbar-nav navbar-right">
-        <li><%= link_to "Home", root_path %></li>
-        <li><%= link_to "Help", help_path %></li>
+        <li><%= link_to t(:home), root_path %></li>
+        <li><%= link_to t(:help), help_path %></li>
         <% if logged_in? %>
-          <li><%= link_to "Users", users_path %></li>
+          <li><%= link_to t(:users), users_path %></li>
           <li class="dropdown">
             <a href="#" id="account" class="dropdown-toggle">
-              Account <b class="caret"></b>
+              <%= t :account %> <b class="caret"></b>
             </a>
             <ul id="dropdown-menu" class="dropdown-menu">
-              <li><%= link_to "Profile", current_user %></li>
-              <li><%= link_to "Settings", edit_user_path(current_user) %></li>
+              <li><%= link_to t(:profile), current_user %></li>
+              <li><%= link_to t(:settings), edit_user_path(current_user) %></li>
               <li class="divider"></li>
               <li>
-                <%= link_to "Log out", logout_path,
+                <%= link_to t(:log_out), logout_path,
                                        data: { "turbo-method": :delete } %>
               </li>
             </ul>
           </li>
         <% else %>
-          <li><%= link_to "Log in", login_path %></li>
+          <li><%= link_to t(:log_in), login_path %></li>
         <% end %>
       </ul>
     </nav>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -18,7 +18,7 @@
         <li><%= link_to t(:help), help_path %></li>
         <% if logged_in? %>
           <li><%= link_to t(:users), users_path %></li>
-          <li><%= link_to "newpost", newpost_path %></li>
+          <li><%= link_to t(:latest), newpost_path %></li>
           <li class="dropdown">
             <a href="#" id="account" class="dropdown-toggle">
               <%= t :account %> <b class="caret"></b>

--- a/app/views/microposts/_micropost.html.erb
+++ b/app/views/microposts/_micropost.html.erb
@@ -17,12 +17,12 @@
     <% end %>
   </span>
   <span class="timestamp">
-    Posted <%= time_ago_in_words(micropost.created_at) %> ago.
+    <%= time_ago_in_words(micropost.created_at) %>
     <% if current_user?(micropost.user) %>
-      <%= link_to "削除", micropost, data: { "turbo-method": :delete,
+      <%= link_to t(:delete_post), micropost, data: { "turbo-method": :delete,
                                                turbo_confirm: "You sure?" } %>
       <% if !micropost.is_fixed %>
-      <%= link_to "固定", fix_micropost_path(micropost.id), data: { "turbo-method": :post,          #deleteなど固定されていないメソッドを追加した場合は、パス(_path)を書く必要あり
+      <%= link_to t(:fix_post), fix_micropost_path(micropost.id), data: { "turbo-method": :post,          #deleteなど固定されていないメソッドを追加した場合は、パス(_path)を書く必要あり
                                                turbo_confirm: "You sure?" } %>
       <% end %>
     <% end %>

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,5 +1,5 @@
-<% provide(:title, 'Reset password') %>
-<h1>Reset password</h1>
+<% provide(:title, t(:reset_password)) %>
+<h1><%= t :reset_password %></h1>
 
 <div class="row">
   <div class="col-md-6 col-md-offset-3">
@@ -14,7 +14,7 @@
       <%= f.label :password_confirmation, "Confirmation" %>
       <%= f.password_field :password_confirmation, class: 'form-control' %>
       
-      <%= f.submit "Update password", class: "btn btn-primary" %>
+      <%= f.submit t(:update_password), class: "btn btn-primary" %>
     <% end %>
   </div>
 </div>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -1,5 +1,5 @@
-<% provide(:title, "Forgot password") %>
-<h1>Forgot password</h1>
+<% provide(:title, t(:forgot_password)) %>
+<h1><%= t :forgot_password %></h1>
 
 <div class="row">
   <div class="col-md-6 col-md-offset-3">
@@ -7,7 +7,7 @@
       <%= f.label :email %>
       <%= f.email_field :email, class: 'form-control' %>
 
-      <%= f.submit "Submit", class: "btn btn-primary" %>
+      <%= f.submit t(:submit_email), class: "btn btn-primary" %>
     <% end %>
   </div>
 </div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,5 +1,5 @@
-<% provide(:title, "Log in") %>
-<h1>Log in</h1>
+<% provide(:title, t(:log_in)) %>
+<h1><%= t :log_in %></h1>
 
 <div class="row">
   <div class="col-md-6 col-md-offset-3">
@@ -9,17 +9,17 @@
       <%= f.email_field :email, class: 'form-control' %>
 
       <%= f.label :password %>
-      <%= link_to "(forgot password)", new_password_reset_path %>
+      <%= link_to "(#{t :forgot_password})", new_password_reset_path %>
       <%= f.password_field :password, class: 'form-control' %>
 
       <%= f.label :remember_me, class: "checkbox inline" do %>
         <%= f.check_box :remember_me %>
-        <span>Remember me on this computer</span>
+        <span><%= t :remember_me %></span>
       <% end %>
 
-      <%= f.submit "Log in", class: "btn btn-primary" %>
+      <%= f.submit t(:log_in), class: "btn btn-primary" %>
     <% end %>
 
-    <p>New user? <%= link_to "Sign up now!", signup_path %></p>
+    <p><%= t :new_user? %> <%= link_to t(:sign_up_now!), signup_path %></p>
   </div>
 </div>

--- a/app/views/shared/_fixed.html.erb
+++ b/app/views/shared/_fixed.html.erb
@@ -1,5 +1,5 @@
 <% if @fixed_item %>
-  <h3>固定Micropost</h3>
+  <h3><%= t :fixed_micropost %></h3>
   <ol class="microposts">
     <%= render @fixed_item %>
   </ol>

--- a/app/views/shared/_micropost_form.html.erb
+++ b/app/views/shared/_micropost_form.html.erb
@@ -1,9 +1,9 @@
 <%= form_with(model: @micropost) do |f| %>
   <%= render 'shared/error_messages', object: f.object %>
   <div class="field">
-    <%= f.text_area :content, placeholder: "Compose new micropost..." %>
+    <%= f.text_area :content, placeholder: t(:compose_new_micropost) %>
   </div>
-  <%= f.submit "Post", class: "btn btn-primary" %>
+  <%= f.submit t(:post_micropost), class: "btn btn-primary" %>
   <span class="image">
     <%= f.file_field :image, accept: "image/jpeg,image/gif,image/png" %>
   </span>

--- a/app/views/shared/_newfollow.html.erb
+++ b/app/views/shared/_newfollow.html.erb
@@ -6,6 +6,6 @@
   <%=  @newpost_items%>
 <% else %>
 <ol class="microposts">
-  <p style="color:silver">フォローしているひとの最新の投稿はありません。</p>
+  <p style="color:silver"><%= t :no_latest_microposts %></p>
 </ol>
 <% end %>

--- a/app/views/shared/_stats.html.erb
+++ b/app/views/shared/_stats.html.erb
@@ -4,12 +4,12 @@
     <strong id="following" class="stat">
       <%= @user.following.count %>
     </strong>
-    フォロー
+    <%= t :following %>
   </a>
   <a href="<%= followers_user_path(@user) %>">
     <strong id="followers" class="stat">
       <%= @user.followers.count %>
     </strong>
-    フォロワー
+    <%= t :followers %>
   </a>
 </div>

--- a/app/views/shared/_user_info.html.erb
+++ b/app/views/shared/_user_info.html.erb
@@ -3,5 +3,5 @@
   <%= current_user.name %><%#
   %><span class="nickname"><%= current_user.nickname %></span>
 </h1>
-<span><%= link_to "マイページ", current_user %></span>
+<span><%= link_to t(:view_my_profile), current_user %></span>
 <span><%= pluralize(current_user.microposts.count, "micropost") %></span>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -23,7 +23,7 @@
   </div>
 <% else %>
   <div class="center jumbotron">
-    <h1>わんわんお<br>にようこそ！</h1>
+    <h1><%= t :welcome %></h1>
 
     <h2>
       This is the home page for the
@@ -31,7 +31,7 @@
       sample application.
     </h2>
 
-    <%= link_to "新規登録", signup_path, class: "btn btn-lg btn-primary" %>
+    <%= link_to t(:sign_up_now!), signup_path, class: "btn btn-lg btn-primary" %>
   </div>
 
   <%= link_to image_tag("rails.svg", alt: "Rails logo", width: "200px"),

--- a/app/views/static_pages/newpost.html.erb
+++ b/app/views/static_pages/newpost.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
     <div class="col-md-8">
-      <h3>最新のフォロワーの投稿</h3>
+      <h3><%= t :latest_microposts_by_following %></h3>
       <%= render 'shared/newfollow' %>
     </div>
 </div>

--- a/app/views/users/_follow.html.erb
+++ b/app/views/users/_follow.html.erb
@@ -1,4 +1,4 @@
 <%= form_with(model: current_user.active_relationships.build) do |f| %>
   <div><%= hidden_field_tag :followed_id, @user.id %></div>
-  <%= f.submit "フォローする", class: "btn btn-primary" %>
+  <%= f.submit t(:follow), class: "btn btn-primary" %>
 <% end %>

--- a/app/views/users/_unfollow.html.erb
+++ b/app/views/users/_unfollow.html.erb
@@ -1,4 +1,4 @@
 <%= form_with(model: current_user.active_relationships.find_by(followed: @user),
               html: { method: :delete }) do |f| %>
-  <%= f.submit "フォロー中", class: "btn" %>
+  <%= f.submit t(:unfollow), class: "btn" %>
 <% end %>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -2,7 +2,7 @@
   <%= gravatar_for user, size: 50 %>
   <%= link_to "#{user.name}#{user.nickname}", user %>
   <% if current_user.admin? && !current_user?(user) %>
-    | <%= link_to "delete", user, data: { "turbo-method": :delete,
+    | <%= link_to t(:delete_user), user, data: { "turbo-method": :delete,
       turbo_confirm: "You sure?" } %>
       
   <% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,5 +1,5 @@
 <% provide(:title, "Edit user") %>
-<h1>Update your profile</h1>
+<h1><%= t :update_your_profile %></h1>
 
 <div class="row">
   <div class="col-md-6 col-md-offset-3">
@@ -24,12 +24,14 @@
       <%= f.label :introduce %>
       <%= f.text_area :introduce,  class: 'form-control' %>
 
-      <%= f.submit "Save changes", class: "btn btn-primary" %>
+      <%= f.submit t(:submit_profile), class: "btn btn-primary" %>
     <% end %>
 
     <div class="gravatar_edit">
       <%= gravatar_for @user %>
-      <a href="https://gravatar.com/emails" target="_blank">change</a>
+      <a href="https://gravatar.com/emails" target="_blank">
+        <%= t :change_gravatar %>
+      </a>
     </div>
   </div>
 </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,5 +1,5 @@
-<% provide(:title, 'All users') %>
-<h1>All users</h1>
+<% provide(:title, t(:all_users)) %>
+<h1><%= t :all_users %></h1>
 
 <%= will_paginate %>
 

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,5 +1,5 @@
-<% provide(:title, 'Sign up') %>
-<h1>Sign up</h1>
+<% provide(:title, t(:sign_up)) %>
+<h1><%= t :sign_up%></h1>
 
 <div class="row">
   <div class="col-md-6 col-md-offset-3">
@@ -18,7 +18,7 @@
       <%= f.label :password_confirmation, "Confirmation" %>
       <%= f.password_field :password_confirmation, class: 'form-control' %>
 
-      <%= f.submit "Create my account", class: "btn btn-primary" %>
+      <%= f.submit t(:create_my_account), class: "btn btn-primary" %>
     <% end %>
   </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -10,7 +10,7 @@
     </section>
     <section class="stats">
       <%= render 'shared/stats' %>
-      <p>自己紹介</p>
+      <p><%= t :introduction %></p>
       <p style = "overflow-wrap: break-word;">
         <%= @user.introduce %>
       </p>

--- a/app/views/users/show_follow.html.erb
+++ b/app/views/users/show_follow.html.erb
@@ -7,7 +7,7 @@
         <%= @user.name %><%#
         %><span class="nickname"><%= @user.nickname %></span>
       </h1>
-      <span><%= link_to "マイページ", @user %></span>
+      <span><%= link_to t(:view_my_profile), @user %></span>
       <span><strong>Microposts:</strong> <%= @user.microposts.count %></span>
     </section>
     <section class="stats">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,33 +1,270 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t "hello"
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t("hello") %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# The following keys must be escaped otherwise they will not be retrieved by
-# the default I18n backend:
-#
-# true, false, on, off, yes, no
-#
-# Instead, surround them with single quotes.
-#
-# en:
-#   "true": "foo"
-#
-# To learn more, please read the Rails Internationalization guide
-# available at https://guides.rubyonrails.org/i18n.html.
-
 en:
-  hello: "Hello world"
+  bow_wow_woo: Bow-Wow-Woo
+
+  welcome: "🐕Welcome to Bow-Wow-Woo!"
+  sign_up_now!: "Sign up now!"
+
+  home: Home
+  help: Help
+  users: Users
+  account: Account
+  profile: Profile
+  settings: Settings
+
+  follow: Follow
+  unfollow: Unfollow
+  following: Following
+  followers: Followers
+  view_my_profile: "view my profile"
+  
+  delete_post: delete
+  fix_post: fix
+
+  forgot_password: "Forgot password"
+  submit_email: Submit
+  reset_password: "Reset password"
+  update_password: "Update password"
+
+  log_in: "Log in"
+  log_out: "Log out"
+  remember_me: "Remember me on this computer"
+  new_user?: "New user?"
+
+  fixed_micropost: "Fixed Micropost"
+
+  compose_new_micropost: "Compose new micropost..."
+  post_micropost: Post
+
+  delete_user: delete
+
+  update_your_profile: "Update your profile"
+  submit_profile: "Save changes"
+  change_gravatar: change
+
+  all_users: "All users"
+
+  will_paginate:
+    previous_label: "← Prev"
+    next_label: "Next →"
+
+  sign_up: "Sign up"
+  create_my_account: "Create my account"
+
+  introduction: "Introduction"
+
+# https://github.com/svenfuchs/rails-i18n/blob/master/rails/locale/en-US.yml
+  activerecord:
+    errors:
+      messages:
+        record_invalid: 'Validation failed: %{errors}'
+        restrict_dependent_destroy:
+          has_one: Cannot delete record because a dependent %{record} exists
+          has_many: Cannot delete record because dependent %{record} exist
+  date:
+    abbr_day_names:
+    - Sun
+    - Mon
+    - Tue
+    - Wed
+    - Thu
+    - Fri
+    - Sat
+    abbr_month_names:
+    -
+    - Jan
+    - Feb
+    - Mar
+    - Apr
+    - May
+    - Jun
+    - Jul
+    - Aug
+    - Sep
+    - Oct
+    - Nov
+    - Dec
+    day_names:
+    - Sunday
+    - Monday
+    - Tuesday
+    - Wednesday
+    - Thursday
+    - Friday
+    - Saturday
+    formats:
+      default: "%m-%d-%Y"
+      long: "%B %d, %Y"
+      short: "%b %d"
+    month_names:
+    -
+    - January
+    - February
+    - March
+    - April
+    - May
+    - June
+    - July
+    - August
+    - September
+    - October
+    - November
+    - December
+    order:
+    - :month
+    - :day
+    - :year
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: about %{count} hour
+        other: about %{count} hours
+      about_x_months:
+        one: about %{count} month
+        other: about %{count} months
+      about_x_years:
+        one: about %{count} year
+        other: about %{count} years
+      almost_x_years:
+        one: almost %{count} year
+        other: almost %{count} years
+      half_a_minute: half a minute
+      less_than_x_seconds:
+        one: less than %{count} second
+        other: less than %{count} seconds
+      less_than_x_minutes:
+        one: less than a minute
+        other: less than %{count} minutes
+      over_x_years:
+        one: over %{count} year
+        other: over %{count} years
+      x_seconds:
+        one: "%{count} second"
+        other: "%{count} seconds"
+      x_minutes:
+        one: "%{count} minute"
+        other: "%{count} minutes"
+      x_days:
+        one: "%{count} day"
+        other: "%{count} days"
+      x_months:
+        one: "%{count} month"
+        other: "%{count} months"
+      x_years:
+        one: "%{count} year"
+        other: "%{count} years"
+    prompts:
+      second: Second
+      minute: Minute
+      hour: Hour
+      day: Day
+      month: Month
+      year: Year
+  errors:
+    format: "%{attribute} %{message}"
+    messages:
+      accepted: must be accepted
+      blank: can't be blank
+      confirmation: doesn't match %{attribute}
+      empty: can't be empty
+      equal_to: must be equal to %{count}
+      even: must be even
+      exclusion: is reserved
+      greater_than: must be greater than %{count}
+      greater_than_or_equal_to: must be greater than or equal to %{count}
+      in: must be in %{count}
+      inclusion: is not included in the list
+      invalid: is invalid
+      less_than: must be less than %{count}
+      less_than_or_equal_to: must be less than or equal to %{count}
+      model_invalid: 'Validation failed: %{errors}'
+      not_a_number: is not a number
+      not_an_integer: must be an integer
+      odd: must be odd
+      other_than: must be other than %{count}
+      present: must be blank
+      required: must exist
+      taken: has already been taken
+      too_long:
+        one: is too long (maximum is %{count} character)
+        other: is too long (maximum is %{count} characters)
+      too_short:
+        one: is too short (minimum is %{count} character)
+        other: is too short (minimum is %{count} characters)
+      wrong_length:
+        one: is the wrong length (should be %{count} character)
+        other: is the wrong length (should be %{count} characters)
+    template:
+      body: 'There were problems with the following fields:'
+      header:
+        one: "%{count} error prohibited this %{model} from being saved"
+        other: "%{count} errors prohibited this %{model} from being saved"
+  helpers:
+    select:
+      prompt: Please select
+    submit:
+      create: Create %{model}
+      submit: Save %{model}
+      update: Update %{model}
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "$"
+    format:
+      delimiter: ","
+      precision: 3
+      round_mode: default
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: Billion
+          million: Million
+          quadrillion: Quadrillion
+          thousand: Thousand
+          trillion: Trillion
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: ", and "
+      two_words_connector: " and "
+      words_connector: ", "
+  time:
+    am: am
+    formats:
+      default: "%a, %d %b %Y %I:%M:%S %p %Z"
+      long: "%B %d, %Y %I:%M %p"
+      short: "%d %b %I:%M %p"
+    pm: pm

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,6 +10,7 @@ en:
   account: Account
   profile: Profile
   settings: Settings
+  latest: Latest
 
   follow: Follow
   unfollow: Unfollow
@@ -51,6 +52,9 @@ en:
   create_my_account: "Create my account"
 
   introduction: "Introduction"
+
+  latest_microposts_by_following: "Latest microposts by following accounts"
+  no_latest_microposts: "No latest microposts."
 
 # https://github.com/svenfuchs/rails-i18n/blob/master/rails/locale/en-US.yml
   activerecord:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -10,6 +10,7 @@ ja:
   account: アカウント
   profile: プロフィール
   settings: 設定
+  latest: 最新
 
   follow: フォローする
   unfollow: フォロー中
@@ -51,6 +52,9 @@ ja:
   create_my_account: アカウントを作成
 
   introduction: 自己紹介
+
+  latest_microposts_by_following: "フォローしている人の最新の投稿"
+  no_latest_microposts: "最新のMicropostはありません。"
 
   # https://github.com/svenfuchs/rails-i18n/blob/master/rails/locale/ja.yml
   activerecord:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,236 @@
+ja:
+  bow_wow_woo: わんわんお
+
+  welcome: 🐕わんわんおにようこそ！
+  sign_up_now!: 登録する
+
+  home: ホーム
+  help: ヘルプ
+  users: ユーザー
+  account: アカウント
+  profile: プロフィール
+  settings: 設定
+
+  follow: フォローする
+  unfollow: フォロー中
+  following: フォロー
+  followers: フォロワー
+  view_my_profile: プロフィール
+
+  delete_post: 削除
+  fix_post: 固定
+
+  forgot_password: パスワードを忘れた場合
+  submit_email: 送信
+  reset_password: パスワードをリセットする
+  update_password: 変更する
+
+  log_in: ログイン
+  log_out: ログアウト
+  remember_me: 次回から自動でログインする
+  new_user?: まだ登録していませんか？
+
+  fixed_micropost: 固定されたMicropost
+
+  compose_new_micropost: 今何してる？
+  post_micropost: ポスト
+
+  delete_user: 削除
+
+  update_your_profile: プロフィールを更新する
+  submit_profile: 保存
+  change_gravatar: 変更
+
+  all_users: 全てのユーザー
+
+  will_paginate:
+    previous_label: "← 前"
+    next_label: "次 →"
+
+  sign_up: 登録する
+  create_my_account: アカウントを作成
+
+  introduction: 自己紹介
+
+  # https://github.com/svenfuchs/rails-i18n/blob/master/rails/locale/ja.yml
+  activerecord:
+    errors:
+      messages:
+        record_invalid: "バリデーションに失敗しました: %{errors}"
+        restrict_dependent_destroy:
+          has_one: "%{record}が存在しているので削除できません"
+          has_many: "%{record}が存在しているので削除できません"
+  date:
+    abbr_day_names:
+      - 日
+      - 月
+      - 火
+      - 水
+      - 木
+      - 金
+      - 土
+    abbr_month_names:
+      -
+      - 1月
+      - 2月
+      - 3月
+      - 4月
+      - 5月
+      - 6月
+      - 7月
+      - 8月
+      - 9月
+      - 10月
+      - 11月
+      - 12月
+    day_names:
+      - 日曜日
+      - 月曜日
+      - 火曜日
+      - 水曜日
+      - 木曜日
+      - 金曜日
+      - 土曜日
+    formats:
+      default: "%Y/%m/%d"
+      long: "%Y年%m月%d日(%a)"
+      short: "%m/%d"
+    month_names:
+      -
+      - 1月
+      - 2月
+      - 3月
+      - 4月
+      - 5月
+      - 6月
+      - 7月
+      - 8月
+      - 9月
+      - 10月
+      - 11月
+      - 12月
+    order:
+      - :year
+      - :month
+      - :day
+  datetime:
+    distance_in_words:
+      about_x_hours: 約%{count}時間
+      about_x_months: 約%{count}ヶ月
+      about_x_years: 約%{count}年
+      almost_x_years: "%{count}年弱"
+      half_a_minute: 30秒前後
+      less_than_x_seconds: "%{count}秒未満"
+      less_than_x_minutes: "%{count}分未満"
+      over_x_years: "%{count}年以上"
+      x_seconds: "%{count}秒"
+      x_minutes: "%{count}分"
+      x_days: "%{count}日"
+      x_months: "%{count}ヶ月"
+      x_years: "%{count}年"
+    prompts:
+      second: 秒
+      minute: 分
+      hour: 時
+      day: 日
+      month: 月
+      year: 年
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      accepted: を受諾してください
+      blank: を入力してください
+      confirmation: と%{attribute}の入力が一致しません
+      empty: を入力してください
+      equal_to: は%{count}にしてください
+      even: は偶数にしてください
+      exclusion: は予約されています
+      greater_than: は%{count}より大きい値にしてください
+      greater_than_or_equal_to: は%{count}以上の値にしてください
+      in: は%{count}の範囲に含めてください
+      inclusion: は一覧にありません
+      invalid: は不正な値です
+      less_than: は%{count}より小さい値にしてください
+      less_than_or_equal_to: は%{count}以下の値にしてください
+      model_invalid: "バリデーションに失敗しました: %{errors}"
+      not_a_number: は数値で入力してください
+      not_an_integer: は整数で入力してください
+      odd: は奇数にしてください
+      other_than: は%{count}以外の値にしてください
+      present: は入力しないでください
+      required: を入力してください
+      taken: はすでに存在します
+      too_long: は%{count}文字以内で入力してください
+      too_short: は%{count}文字以上で入力してください
+      wrong_length: は%{count}文字で入力してください
+    template:
+      body: 次の項目を確認してください
+      header: "%{model}に%{count}個のエラーが発生しました"
+  helpers:
+    select:
+      prompt: 選択してください
+    submit:
+      create: 登録する
+      submit: 保存する
+      update: 更新する
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n%u"
+        precision: 0
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: 円
+    format:
+      delimiter: ","
+      precision: 3
+      round_mode: default
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十億
+          million: 百万
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ""
+      format:
+        delimiter: ""
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n%u"
+        units:
+          byte: バイト
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ""
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ""
+  support:
+    array:
+      last_word_connector: "、"
+      two_words_connector: "、"
+      words_connector: "、"
+  time:
+    am: 午前
+    formats:
+      default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      long: "%Y/%m/%d %H:%M"
+      short: "%m/%d %H:%M"
+    pm: 午後

--- a/test/integration/microposts_interface_test.rb
+++ b/test/integration/microposts_interface_test.rb
@@ -20,7 +20,7 @@ class MicropostsInterfaceTest < MicropostsInterface
       post microposts_path, params: { micropost: { content: "" } }
     end
     assert_select 'div#error_explanation'
-    assert_select 'a[href=?]', '/?page=2'  # 正しいページネーションリンク
+    assert_select 'a[href=?]', "/?locale=#{I18n.locale}&page=2"  # 正しいページネーションリンク
   end
 
   test "should create a micropost on valid submission" do
@@ -35,7 +35,7 @@ class MicropostsInterfaceTest < MicropostsInterface
 
   test "should have micropost delete links on own profile page" do
     get user_path(@user)
-    assert_select 'a', text: '削除'
+    assert_select 'a', text: I18n.t(:delete_post)
   end
 
   test "should be able to delete own micropost" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,7 +22,22 @@ class ActiveSupport::TestCase
   end
 end
 
+module AddQueryParametersToPath
+  # Railsが自動生成したパスメソッドをクエリパラメータを含むようにオーバーライドする
+  def add_query_parameters_to(*path_methods)
+    path_with_query_parameters = lambda do |*values|
+      "#{super(*values)}?locale=#{I18n.locale}"
+    end
+
+    path_methods.each { define_method _1, path_with_query_parameters }
+  end
+end
+
 class ActionDispatch::IntegrationTest
+  extend AddQueryParametersToPath
+
+  path_url_methods = %w[root login logout user help about contact users].flat_map { %I[#{_1}_path #{_1}_url] }
+  add_query_parameters_to *path_url_methods
 
   # テストユーザーとしてログインする
   def log_in_as(user, password: 'password', remember_me: '1')


### PR DESCRIPTION
Close #7

### やったこと
- 辞書を作りました(`ja.yml`, `en.yml`)。
- 各ページの主要な文字列を多言語対応版に置き換えました。
- localeの設定をクエリパラメータから取るようにしました。
  - http://localhost:3000/?locale=en, http://localhost:3000/?locale=ja のように使います。
- テストを直しました。
  - 上の変更でURL末尾にクエリパラメータが付いたため、リダイレクト検証などのパス・URL関連のテストが落ちていました。
  - Railsがデフォルトで定義するsuffixが`_path`、`_url`のメソッドを、クエリパラメータを含むようにオーバーライドしました。
  - テストにパスが直書きしてあるものは、そのまま書き換えました。
- @hosogimiho さんの`newpost`ページを多言語対応させました。
  - 一部表現を変えています。