### PR TITLE
fix: Likeユーザ一覧画面でコントロールが表示されてしまうのを修正

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -418,3 +418,7 @@ span.image {
   outline: none;
   box-shadow: 0 3px 3px 0 rgba(0, 0, 0, .2);
 }
+
+.hidden_tag {
+  display: none;
+}


### PR DESCRIPTION
CSSが消えてしまっていたようですので戻しました。

![image](https://github.com/NaCl-Ltd/intern-2023-B/assets/77904659/f72e8879-c90f-448c-89c7-2bb38a500196)
